### PR TITLE
Fix: make series title visible in e-ink theme

### DIFF
--- a/Native Themes/E-Ink/e-ink.css
+++ b/Native Themes/E-Ink/e-ink.css
@@ -196,6 +196,10 @@
     --popover-bg-color: lightgrey;
     --popover-border-color: lightgrey;
 
+    /* Series Detail */
+    --detail-title-color: black;
+    --detail-subtitle-color: darkgrey;
+
     /* Search */
     --search-result-text-lite-color: rgba(0,0,0,1);
 


### PR DESCRIPTION
Series title defaults to `white`. Change it to black for the e-ink theme.

<img width="1298" height="426" alt="image" src="https://github.com/user-attachments/assets/7629ea03-2ea5-4d00-9f17-f9dff17ec2ab" />


Requires 